### PR TITLE
Fix Unit Of Density in Path Length

### DIFF
--- a/src/physics/degas2/DG2Physics.h
+++ b/src/physics/degas2/DG2Physics.h
@@ -228,7 +228,7 @@ public:
     double l = -Kokkos::log(x) /
                (field_info.electron_density * sigma_ion +
                 field_info.ion_density * sigma_cx) *
-               0.01; // m. n in cm^-3
+               1e4; // m. n in m^-3, cx in cm^2. Net unit m^3/cm^2. Conversion factor 1e4.
     particle_info.position[0] += l * particle_info.direction[0];
     particle_info.position[1] += l * particle_info.direction[1];
     particle_info.position[2] += l * particle_info.direction[2];


### PR DESCRIPTION
I had treated the density in units of cm^-3 which meant effectively the plasma was way too dense. The mean free path is ultimately a factor of 10^6 larger now.